### PR TITLE
Update anharmonicities.html

### DIFF
--- a/docs/API/circuit_functions/anharmonicities.html
+++ b/docs/API/circuit_functions/anharmonicities.html
@@ -222,14 +222,14 @@ ex: <code class="docutils literal notranslate"><span class="pre">L=1e-9</span></
 </table>
 <p class="rubric">Notes</p>
 <p>The Hamiltonian of the circuit is</p>
-<p><span class="math notranslate nohighlight">\(\hat{H} = \sum_m hf_m\hat{a}_m^\dagger\hat{a}_m + \sum_j E_j[1-\cos{\hat{\varphi_j}}-\frac{\hat{\varphi_j}^2}{2}]\)</span>,</p>
+<p><span class="math notranslate nohighlight">\(\hat{H} = \sum_m hf_m\hat{a}_m^\dagger\hat{a}_m + \sum_j E_j[1-\cos{\hat{\varphi}_j}-\frac{\hat{\varphi}_j^2}{2}]\)</span>,</p>
 <p>where <span class="math notranslate nohighlight">\(\hat{a}_m\)</span> is the annihilation operator of the m-th
 normal mode of the circuit and <span class="math notranslate nohighlight">\(f_m\)</span> is the frequency of
 the m-th normal mode, <span class="math notranslate nohighlight">\(E_j\)</span> is the Josephson energy of
 the j-th junction and</p>
-<p><span class="math notranslate nohighlight">\(\varphi_j = \sum_m\frac{\phi_{zpf,m,j}}{\phi_0}(\hat{a}_m^\dagger+\hat{a}_m)\)</span>.</p>
-<p>where <span class="math notranslate nohighlight">\(phi_0 = \hbar/2e\)</span> and</p>
-<p><span class="math notranslate nohighlight">\(\phi_{zpf,m} = \sqrt{\frac{\hbar}{\omega_mImY'(\omega_m)}}\)</span></p>
+<p><span class="math notranslate nohighlight">\(\varphi_j = \sum_m\frac{\phi_{\text{zpf,m,j}}}{\phi_0}(\hat{a}_m^\dagger+\hat{a}_m)\)</span>.</p>
+<p>where <span class="math notranslate nohighlight">\(\phi_0 = \hbar/2e\)</span> and</p>
+<p><span class="math notranslate nohighlight">\(\phi_{\text{zpf,m}} = \sqrt{\hbar\left(\omega_m\operatorname{Im}Y'(\omega_m)\right)^{-1}}\)</span></p>
 <p>is the zero-point fluctuations in flux if a mode through the junction,
 with frequency <span class="math notranslate nohighlight">\(\omega_m\)</span> and admittance to the rest of the circuit <span class="math notranslate nohighlight">\(Y\)</span></p>
 <p>By keeping only terms which play a role up to first order perturbation</p>
@@ -237,7 +237,7 @@ with frequency <span class="math notranslate nohighlight">\(\omega_m\)</span> an
 <p>This function returns the anharmonicities</p>
 <p><span class="math notranslate nohighlight">\(A_m = \sum_j A_{m,j}\)</span></p>
 <p>where</p>
-<p><span class="math notranslate nohighlight">\(A_{m,j} = E_j/2/h\left(\frac{\phi_{zpf,m,j}}{\phi_0}\right)^4\)</span></p>
+<p><span class="math notranslate nohighlight">\(A_{m,j} = E_j/(2h)\left(\frac{\phi_{\text{zpf,m,j}}}{\phi_0}\right)^4\)</span></p>
 <p>is the contribution of junction j to the total anharmonicity of a mode m.</p>
 </dd></dl>
 

--- a/docs/API/circuit_functions/hamiltonian.html
+++ b/docs/API/circuit_functions/hamiltonian.html
@@ -247,7 +247,7 @@ ex: <code class="docutils literal notranslate"><span class="pre">L=1e-9</span></
 <p class="rubric">Notes</p>
 <p>The Hamiltonian of the circuit, with the non-linearity of the Josephson junctions
 Taylor-expanded, is given by</p>
-<p><span class="math notranslate nohighlight">\(\hat{H} = \sum_{m\in\text{modes}} \hbar \omega_m\hat{a}_m^\dagger\hat{a}_m + \sum_j\sum_{2n\le\text{taylor}}E_j\frac{(-1)^{n+1}}{(2n)!}\left[\frac{\phi_{zpf,m,j}}{\phi_0}(\hat{a}_m^\dagger+\hat{a}_m)\right]^{2n}\)</span>,</p>
+<p><span class="math notranslate nohighlight">\(\hat{H} = \sum_{m\in\text{modes}} \hbar \omega_m\hat{a}_m^\dagger\hat{a}_m + \sum_j\sum_{2n\le\text{taylor}}E_j\frac{(-1)^{n+1}}{(2n)!}\left[\frac{\phi_{\text{zpf,m,j}}}{\phi_0}(\hat{a}_m^\dagger+\hat{a}_m)\right]^{2n}\)</span>,</p>
 <p>where <span class="math notranslate nohighlight">\(\hat{a}_m\)</span> is the annihilation operator of the m-th
 normal mode of the circuit and <span class="math notranslate nohighlight">\(f_m\)</span> is the frequency of
 the m-th normal mode, <span class="math notranslate nohighlight">\(E_j\)</span> is the Josephson energy of
@@ -257,7 +257,7 @@ the j-th junction and <span class="math notranslate nohighlight">\(\phi_0 = \hba
 by multiplying the voltage transfer function between a reference junction
 and the junction <span class="math notranslate nohighlight">\(j\)</span> with the zero-point fluctuations
 of the reference junction</p>
-<p><span class="math notranslate nohighlight">\(\phi_{zpf,m} = \sqrt{\frac{\hbar}{\omega_mImY'(\omega_m)}}\)</span></p>
+<p><span class="math notranslate nohighlight">\(\phi_{\text{zpf,m}} = \sqrt{\hbar\left(\omega_m\operatorname{Im}Y'(\omega_m)\right)^{-1}}\)</span></p>
 <p>where <span class="math notranslate nohighlight">\(Y\)</span> is the admittance of
 the circuit calculated at the nodes of the reference junction.</p>
 <p>If the circuit has at least one resistor, the voltage transfer

--- a/docs/API/circuit_functions/kerr.html
+++ b/docs/API/circuit_functions/kerr.html
@@ -227,12 +227,12 @@ ex: <code class="docutils literal notranslate"><span class="pre">L=1e-9</span></
 </table>
 <p class="rubric">Notes</p>
 <p>The Hamiltonian of the circuit is</p>
-<p><span class="math notranslate nohighlight">\(\hat{H} = \sum_m hf_m\hat{a}_m^\dagger\hat{a}_m + \sum_j E_j[1-\cos{\hat{\varphi_j}}-\frac{\hat{\varphi_j}^2}{2}]\)</span>,</p>
+<p><span class="math notranslate nohighlight">\(\hat{H} = \sum_m hf_m\hat{a}_m^\dagger\hat{a}_m + \sum_j E_j[1-\cos{\hat{\varphi}_j}-\frac{\hat{\varphi}_j^2}{2}]\)</span>,</p>
 <p>where <span class="math notranslate nohighlight">\(\hat{a}_m\)</span> is the annihilation operator of the m-th
 normal mode of the circuit and <span class="math notranslate nohighlight">\(f_m\)</span> is the frequency of
 the m-th normal mode, <span class="math notranslate nohighlight">\(E_j\)</span> is the Josephson energy of
 the j-th junction and</p>
-<p><span class="math notranslate nohighlight">\(\phi_{zpf,m} = \sqrt{\frac{\hbar}{\omega_mImY'(\omega_m)}}\)</span></p>
+<p><span class="math notranslate nohighlight">\(\phi_{\text{zpf,m}} = \sqrt{\hbar\left(\omega_m\operatorname{Im}Y'(\omega_m)\right)^{-1}}\)</span></p>
 <p>is the zero-point fluctuations in flux if a mode through the junction,
 with frequency <span class="math notranslate nohighlight">\(\omega_m\)</span> and admittance to the rest of the circuit <span class="math notranslate nohighlight">\(Y\)</span></p>
 <p>By keeping only terms which play a role up to first order perturbation</p>
@@ -241,7 +241,7 @@ with frequency <span class="math notranslate nohighlight">\(\omega_m\)</span> an
 <p><span class="math notranslate nohighlight">\(K_{mm} = \sum_j A_{m,j}\)</span></p>
 <p><span class="math notranslate nohighlight">\(K_{mn} = \sum_j \sqrt{A_{m,j}}\sqrt{A_{n,j}}\)</span></p>
 <p>where</p>
-<p><span class="math notranslate nohighlight">\(A_{m,j} = E_j/2/h\left(\frac{\phi_{zpf,m,j}}{\phi_0}\right)^4\)</span></p>
+<p><span class="math notranslate nohighlight">(A_{m,j} = E_j/(2h)\left(\frac{\phi_{\text{zpf,m,j}}}{\phi_0}\right)^4\)</span></p>
 <p>is the contribution of junction j to the total anharmonicity of a mode m</p>
 </dd></dl>
 


### PR DESCRIPTION
The docs change from \phi having a m and j as subscript to only having j. I am unsure as to what happens there. Furthermore, the docs show Y as a Y' - not sure what the reason for this is either.