### PR TITLE
Run unit tests and coverage with GitHub Actions

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -28,7 +28,7 @@ jobs:
     - name: Add conda to system path
       shell: bash
       run: |
-        ls -l $CONDA
+        ls -l $CONDA/condabin
         # $CONDA is an environment variable pointing to the root of the miniconda directory
         # echo $CONDA/bin >> $GITHUB_PATH
         # echo $CONDA

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -10,7 +10,7 @@ jobs:
       max-parallel: 5
       matrix:
         ## os: [ubuntu-latest, macOS-12, windows-latest]
-        os: [macOS-12]
+        os: [windows-latest]
         python-version: ["3.7", "3.10", "3.11", "3.12"]
         exclude:
           - os: macOS-12

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -24,5 +24,10 @@ jobs:
         conda env update --file test-environment.yml --name base
     - name: Test with pytest
       run: |
+        # avoid tkinter error
+        # See https://github.com/orgs/community/discussions/62479
+        export DISPLAY=:99
+        Xvfb :99 &
         pytest --cov=src
-        codecov
+    - name: Upload results to Codecov
+      uses: codecov/codecov-action@v4

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -13,7 +13,7 @@ jobs:
         os: [macOS-12]
         python-version: ["3.7", "3.10", "3.11", "3.12"]
         exclude:
-          - os: macos-macOS-12
+          - os: macOS-12
             python-version: "3.7"
           - os: windows-latest
             python-version: "3.7"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -11,7 +11,8 @@ jobs:
       matrix:
         ## os: [ubuntu-latest, macOS-12, windows-latest]
         os: [windows-latest]
-        python-version: ["3.7", "3.10", "3.11", "3.12"]
+        ## python-version: ["3.7", "3.10", "3.11", "3.12"]
+        python-version: ["3.10"]
         exclude:
           - os: macOS-12
             python-version: "3.7"
@@ -27,9 +28,10 @@ jobs:
     - name: Add conda to system path
       shell: bash
       run: |
+        ls -l
         # $CONDA is an environment variable pointing to the root of the miniconda directory
-        echo $CONDA/bin >> $GITHUB_PATH
-        echo $CONDA
+        # echo $CONDA/bin >> $GITHUB_PATH
+        # echo $CONDA
     - name: Install dependencies
       shell: bash
       run: |

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -3,18 +3,20 @@ name: Build status
 on: [push, pull_request, workflow_dispatch]
 
 jobs:
-  build-linux:
+  build:
+
     runs-on: ubuntu-latest
     strategy:
       max-parallel: 5
-      # read this: https://docs.github.com/en/actions/use-cases-and-examples/building-and-testing/building-and-testing-python#using-multiple-python-versions
+      matrix:
+        python-version: [3.7, 3.10, 3.11, 3.12]
 
     steps:
     - uses: actions/checkout@v4
-    - name: Set up Python 3.7
-      uses: actions/setup-python@v3
+    - name: Set up Python
+      uses: actions/setup-python@v5
       with:
-        python-version: '3.7'
+        python-version: ${{ matrix.python-version }}
     - name: Add conda to system path
       run: |
         # $CONDA is an environment variable pointing to the root of the miniconda directory

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -11,6 +11,11 @@ jobs:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
         python-version: ["3.7", "3.10", "3.11", "3.12"]
+        exclude:
+          - os: macos-latest
+            python-version: "3.7"
+          - os: windows-latest
+            python-version: "3.7"
 
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       max-parallel: 5
       matrix:
-        python-version: [3.7, 3.10, 3.11, 3.12]
+        python-version: ["3.7", "3.10", "3.11", "3.12"]
 
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -31,3 +31,5 @@ jobs:
         pytest --cov=src
     - name: Upload results to Codecov
       uses: codecov/codecov-action@v4
+      with:
+        token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -28,14 +28,14 @@ jobs:
     - name: Add conda to system path
       shell: bash
       run: |
-        ls -l $CONDA/condabin
+        ls -l $CONDA/condabin/conda.bat
         # $CONDA is an environment variable pointing to the root of the miniconda directory
         # echo $CONDA/bin >> $GITHUB_PATH
         # echo $CONDA
     - name: Install dependencies
       shell: bash
       run: |
-        conda env update --file test-environment.yml --name base
+        $CONDA/condabin/conda.bat env update --file test-environment.yml --name base
     - name: Test with pytest
       shell: bash
       run: |

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -9,7 +9,8 @@ jobs:
     strategy:
       max-parallel: 5
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        ## os: [ubuntu-latest, macOS-latest, windows-latest]
+        os: [macOS-latest]
         python-version: ["3.7", "3.10", "3.11", "3.12"]
         exclude:
           - os: macos-latest
@@ -27,6 +28,7 @@ jobs:
       run: |
         # $CONDA is an environment variable pointing to the root of the miniconda directory
         echo $CONDA/bin >> $GITHUB_PATH
+        echo $CONDA
     - name: Install dependencies
       run: |
         conda env update --file test-environment.yml --name base

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -28,7 +28,7 @@ jobs:
     - name: Add conda to system path
       shell: bash
       run: |
-        ls -l
+        ls -l $CONDA
         # $CONDA is an environment variable pointing to the root of the miniconda directory
         # echo $CONDA/bin >> $GITHUB_PATH
         # echo $CONDA

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       max-parallel: 5
       matrix:
-        ## os: [ubuntu-latest, macOS-latest, windows-latest]
+        ## os: [ubuntu-latest, macOS-12, windows-latest]
         os: [macOS-latest]
         python-version: ["3.7", "3.10", "3.11", "3.12"]
         exclude:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -10,10 +10,10 @@ jobs:
       max-parallel: 5
       matrix:
         ## os: [ubuntu-latest, macOS-12, windows-latest]
-        os: [macOS-latest]
+        os: [macOS-12]
         python-version: ["3.7", "3.10", "3.11", "3.12"]
         exclude:
-          - os: macos-latest
+          - os: macos-macOS-12
             python-version: "3.7"
           - os: windows-latest
             python-version: "3.7"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -33,5 +33,6 @@ jobs:
         pytest --cov=src
     - name: Upload results to Codecov
       uses: codecov/codecov-action@v4
+      if: ${{ matrix.python-version == '3.12' }}
       with:
         token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -10,9 +10,8 @@ jobs:
       max-parallel: 5
       matrix:
         ## os: [ubuntu-latest, macOS-12, windows-latest]
-        os: [windows-latest]
-        ## python-version: ["3.7", "3.10", "3.11", "3.12"]
-        python-version: ["3.10"]
+        os: [ubuntu-latest]
+        python-version: ["3.7", "3.10", "3.11", "3.12"]
         exclude:
           - os: macOS-12
             python-version: "3.7"
@@ -28,21 +27,20 @@ jobs:
     - name: Add conda to system path
       shell: bash
       run: |
-        ls -l $CONDA/condabin/conda.bat
         # $CONDA is an environment variable pointing to the root of the miniconda directory
-        # echo $CONDA/bin >> $GITHUB_PATH
-        # echo $CONDA
+        echo $CONDA/bin >> $GITHUB_PATH
     - name: Install dependencies
       shell: bash
       run: |
-        $CONDA/condabin/conda.bat env update --file test-environment.yml --name base
+        # $CONDA/condabin/conda.bat env update --file test-environment.yml --name base
+        conda env update --file test-environment.yml --name base
     - name: Test with pytest
       shell: bash
       run: |
         # avoid tkinter error
         # See https://github.com/orgs/community/discussions/62479
-        # export DISPLAY=:99
-        # Xvfb :99 &
+        export DISPLAY=:99
+        Xvfb :99 &
         pytest --cov=src
     - name: Upload results to Codecov
       uses: codecov/codecov-action@v4

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -5,10 +5,11 @@ on: [push, pull_request, workflow_dispatch]
 jobs:
   build:
 
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
     strategy:
       max-parallel: 5
       matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
         python-version: ["3.7", "3.10", "3.11", "3.12"]
 
     steps:
@@ -33,6 +34,8 @@ jobs:
         pytest --cov=src
     - name: Upload results to Codecov
       uses: codecov/codecov-action@v4
-      if: ${{ matrix.python-version == '3.12' }}
+      if: |
+        ${{ matrix.python-version == '3.12' }} &&
+        ${{ matrix.os == 'ubuntu-latest' }}
       with:
         token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,28 @@
+name: Build status
+
+on: [push, pull_request, workflow_dispatch]
+
+jobs:
+  build-linux:
+    runs-on: ubuntu-latest
+    strategy:
+      max-parallel: 5
+      # read this: https://docs.github.com/en/actions/use-cases-and-examples/building-and-testing/building-and-testing-python#using-multiple-python-versions
+
+    steps:
+    - uses: actions/checkout@v4
+    - name: Set up Python 3.7
+      uses: actions/setup-python@v3
+      with:
+        python-version: '3.7'
+    - name: Add conda to system path
+      run: |
+        # $CONDA is an environment variable pointing to the root of the miniconda directory
+        echo $CONDA/bin >> $GITHUB_PATH
+    - name: Install dependencies
+      run: |
+        conda env update --file test-environment.yml --name base
+    - name: Test with pytest
+      run: |
+        pytest --cov=src
+        codecov

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -31,9 +31,11 @@ jobs:
         echo $CONDA/bin >> $GITHUB_PATH
         echo $CONDA
     - name: Install dependencies
+      shell: bash
       run: |
         conda env update --file test-environment.yml --name base
     - name: Test with pytest
+      shell: bash
       run: |
         # avoid tkinter error
         # See https://github.com/orgs/community/discussions/62479

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -25,6 +25,7 @@ jobs:
       with:
         python-version: ${{ matrix.python-version }}
     - name: Add conda to system path
+      shell: bash
       run: |
         # $CONDA is an environment variable pointing to the root of the miniconda directory
         echo $CONDA/bin >> $GITHUB_PATH

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -9,14 +9,8 @@ jobs:
     strategy:
       max-parallel: 5
       matrix:
-        ## os: [ubuntu-latest, macOS-12, windows-latest]
         os: [ubuntu-latest]
         python-version: ["3.7", "3.10", "3.11", "3.12"]
-        exclude:
-          - os: macOS-12
-            python-version: "3.7"
-          - os: windows-latest
-            python-version: "3.7"
 
     steps:
     - uses: actions/checkout@v4
@@ -25,17 +19,13 @@ jobs:
       with:
         python-version: ${{ matrix.python-version }}
     - name: Add conda to system path
-      shell: bash
       run: |
         # $CONDA is an environment variable pointing to the root of the miniconda directory
         echo $CONDA/bin >> $GITHUB_PATH
     - name: Install dependencies
-      shell: bash
       run: |
-        # $CONDA/condabin/conda.bat env update --file test-environment.yml --name base
         conda env update --file test-environment.yml --name base
     - name: Test with pytest
-      shell: bash
       run: |
         # avoid tkinter error
         # See https://github.com/orgs/community/discussions/62479

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -36,8 +36,8 @@ jobs:
       run: |
         # avoid tkinter error
         # See https://github.com/orgs/community/discussions/62479
-        export DISPLAY=:99
-        Xvfb :99 &
+        # export DISPLAY=:99
+        # Xvfb :99 &
         pytest --cov=src
     - name: Upload results to Codecov
       uses: codecov/codecov-action@v4

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Build status and test coverage
 ------------------------------
 
 Master branch: 
-[![TEMP](https://github.com/sebranchett/qucat/actions/workflows/tests.yml/badge.svg?branch=master)](https://github.com/sebranchett/qucat/actions)
+[![TEMP](https://github.com/sebranchett/qucat/actions/workflows/tests.yml/badge.svg?branch=run-tests-gha)](https://github.com/sebranchett/qucat/actions)
 [![Build Status](https://github.com/qucat/qucat/actions/workflows/tests.yml/badge.svg?branch=master)](https://github.com/qucat/qucat/actions)
 [![codecov](https://codecov.io/gh/qucat/qucat/branch/master/graph/badge.svg)](https://codecov.io/gh/qucat/qucat)
 

--- a/README.md
+++ b/README.md
@@ -32,7 +32,8 @@ Build status and test coverage
 ------------------------------
 
 Master branch: 
-[![Build Status](https://travis-ci.com/qucat/qucat.svg?branch=master)](https://travis-ci.com/qucat/qucat)
+[![TEMP](https://github.com/sebranchett/qucat/actions/workflows/tests.yml/badge.svg?branch=master)](https://github.com/sebranchett/qucat/actions)
+[![Build Status](https://github.com/qucat/qucat/actions/workflows/tests.yml/badge.svg?branch=master)](https://github.com/qucat/qucat/actions)
 [![codecov](https://codecov.io/gh/qucat/qucat/branch/master/graph/badge.svg)](https://codecov.io/gh/qucat/qucat)
 
 Contribute

--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ Build status and test coverage
 Master branch: 
 [![TEMP](https://github.com/sebranchett/qucat/actions/workflows/tests.yml/badge.svg?branch=run-tests-gha)](https://github.com/sebranchett/qucat/actions)
 [![Build Status](https://github.com/qucat/qucat/actions/workflows/tests.yml/badge.svg?branch=master)](https://github.com/qucat/qucat/actions)
+[![TEMP](https://codecov.io/gh/sebranchett/qucat/branch/run-tests-gha/graph/badge.svg)](https://codecov.io/gh/sebranchett/qucat)
 [![codecov](https://codecov.io/gh/qucat/qucat/branch/master/graph/badge.svg)](https://codecov.io/gh/qucat/qucat)
 
 Contribute

--- a/README.md
+++ b/README.md
@@ -31,10 +31,8 @@ A selection of tutorials is available [here](https://qucat.org/tutorials/tutoria
 Build status and test coverage
 ------------------------------
 
-Master branch: 
-[![TEMP](https://github.com/sebranchett/qucat/actions/workflows/tests.yml/badge.svg?branch=run-tests-gha)](https://github.com/sebranchett/qucat/actions)
+Master branch:
 [![Build Status](https://github.com/qucat/qucat/actions/workflows/tests.yml/badge.svg?branch=master)](https://github.com/qucat/qucat/actions)
-[![TEMP](https://codecov.io/gh/sebranchett/qucat/branch/run-tests-gha/graph/badge.svg)](https://codecov.io/gh/sebranchett/qucat)
 [![codecov](https://codecov.io/gh/qucat/qucat/branch/master/graph/badge.svg)](https://codecov.io/gh/qucat/qucat)
 
 Contribute

--- a/test-environment.yml
+++ b/test-environment.yml
@@ -1,0 +1,13 @@
+name: test-environment
+channels:
+  - conda-forge
+  - defaults
+dependencies:
+  - scipy
+  - matplotlib
+  - sympy
+  - nbdime
+  - pytest
+  - pytest-cov
+  - codecov
+  - qutip


### PR DESCRIPTION
Travis is no longer active for 'qucat', so this pull request performs unit tests and code coverage analysis using a GitHub action.
The tests are run on Linux only, but with several different versions of Python.

Here are the instructions to load the code coverage analysis to Codecov from the GitHub action (instead of from Travis):
https://docs.codecov.com/docs/adding-the-codecov-token