### PR TITLE
Pip install from index test

### DIFF
--- a/.github/workflows/pip-install-index.yml
+++ b/.github/workflows/pip-install-index.yml
@@ -11,6 +11,12 @@ jobs:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
         python-version: ["3.7", "3.10", "3.11", "3.12"]
+        exclude:
+          - os: macOS-latest
+            python-version: "3.7"
+          - os: windows-latest
+            python-version: "3.7"
+          # Python 3.7 gha no longer supported on macOS and Windows
 
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/pip-install-index.yml
+++ b/.github/workflows/pip-install-index.yml
@@ -1,0 +1,24 @@
+name: Pip install from index
+
+on: [push, workflow_dispatch]
+
+jobs:
+  build:
+
+    runs-on: ${{ matrix.os }}
+    strategy:
+      max-parallel: 5
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+        python-version: ["3.7", "3.10", "3.11", "3.12"]
+
+    steps:
+    - uses: actions/checkout@v4
+    - name: Set up Python
+      uses: actions/setup-python@v5
+      with:
+        python-version: ${{ matrix.python-version }}
+    - name: Install QuCAT
+      run: |
+        pip install qucat
+        python -c "import qucat"


### PR DESCRIPTION
Install QuCAT from the PyPI index, using a GitHub action.
Migrating from Travis.

Added functionality of testing Windows and macOS, instead of Linux only.
Also tests several versions of Python.