### PR TITLE
Python 3.7 no longer supported on ubuntu-latest

### DIFF
--- a/.github/workflows/pip-install-index.yml
+++ b/.github/workflows/pip-install-index.yml
@@ -10,7 +10,7 @@ jobs:
       max-parallel: 5
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: ["3.7", "3.10", "3.11", "3.12"]
+        python-version: ["3.10", "3.11", "3.12"]
         exclude:
           - os: macOS-latest
             python-version: "3.7"

--- a/.github/workflows/pip-install-index.yml
+++ b/.github/workflows/pip-install-index.yml
@@ -26,5 +26,6 @@ jobs:
         python-version: ${{ matrix.python-version }}
     - name: Install QuCAT
       run: |
+        python --version
         pip install qucat
         python -c "import qucat"

--- a/.github/workflows/pip-install-src.yml
+++ b/.github/workflows/pip-install-src.yml
@@ -26,5 +26,6 @@ jobs:
         python-version: ${{ matrix.python-version }}
     - name: Install QuCAT
       run: |
+        python --version
         pip install .
         python -c "import qucat"

--- a/.github/workflows/pip-install-src.yml
+++ b/.github/workflows/pip-install-src.yml
@@ -10,13 +10,7 @@ jobs:
       max-parallel: 5
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: ["3.7", "3.10", "3.11", "3.12"]
-        exclude:
-          - os: macOS-latest
-            python-version: "3.7"
-          - os: windows-latest
-            python-version: "3.7"
-          # Python 3.7 gha no longer supported on macOS and Windows
+        python-version: ["3.10", "3.11", "3.12"]
 
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -10,7 +10,7 @@ jobs:
       max-parallel: 5
       matrix:
         os: [ubuntu-latest]
-        python-version: ["3.7", "3.10", "3.11", "3.12"]
+        python-version: ["3.10", "3.11", "3.12"]
 
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -14,16 +14,14 @@ jobs:
 
     steps:
     - uses: actions/checkout@v4
-    - name: Set up Python
-      uses: actions/setup-python@v5
-      with:
-        python-version: ${{ matrix.python-version }}
     - name: Add conda to system path
       run: |
         # $CONDA is an environment variable pointing to the root of the miniconda directory
         echo $CONDA/bin >> $GITHUB_PATH
+        conda config --add channels defaults
     - name: Install dependencies
       run: |
+        conda install -y python=${{ matrix.python-version }}
         conda env update --file test-environment.yml --name base
     - name: Test with pytest
       run: |
@@ -31,6 +29,7 @@ jobs:
         # See https://github.com/orgs/community/discussions/62479
         export DISPLAY=:99
         Xvfb :99 &
+        python --version
         pytest --cov=src
     - name: Upload results to Codecov
       uses: codecov/codecov-action@v4


### PR DESCRIPTION
Removed Python 3.7 from the list of versions to test.
I also noticed this:
https://github.com/actions/setup-python/issues/833
concerning use of Conda with Github Actions.
The actions now output the Python version so I can check I am using the right one.