### PR TITLE
Adapting environment and MMUSC tutorial to get tests to pass again

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -10,7 +10,7 @@ jobs:
       max-parallel: 5
       matrix:
         os: [ubuntu-latest]
-        python-version: ["3.10", "3.11", "3.12", "3.13"]
+        python-version: ["3.11", "3.12", "3.13"]
 
     steps:
     - uses: actions/checkout@v4
@@ -31,10 +31,10 @@ jobs:
         Xvfb :99 &
         python --version
         python -m pytest --cov=src
-    # - name: Upload results to Codecov
-    #   uses: codecov/codecov-action@v4
-    #   if: |
-    #     ${{ matrix.python-version == '3.13' }} &&
-    #     ${{ matrix.os == 'ubuntu-latest' }}
-    #   with:
-    #     token: ${{ secrets.CODECOV_TOKEN }}
+    - name: Upload results to Codecov
+      uses: codecov/codecov-action@v4
+      if: |
+        ${{ matrix.python-version == '3.13' }} &&
+        ${{ matrix.os == 'ubuntu-latest' }}
+      with:
+        token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -10,7 +10,7 @@ jobs:
       max-parallel: 5
       matrix:
         os: [ubuntu-latest]
-        python-version: ["3.10", "3.11", "3.12"]
+        python-version: ["3.10", "3.11", "3.12", "3.13"]
 
     steps:
     - uses: actions/checkout@v4
@@ -21,7 +21,7 @@ jobs:
         conda config --add channels defaults
     - name: Install dependencies
       run: |
-        conda install -y python=${{ matrix.python-version }}
+        conda install -y python=${{ matrix.python-version }} sqlite
         conda env update --file test-environment.yml --name base
     - name: Test with pytest
       run: |
@@ -30,11 +30,11 @@ jobs:
         export DISPLAY=:99
         Xvfb :99 &
         python --version
-        pytest --cov=src
-    - name: Upload results to Codecov
-      uses: codecov/codecov-action@v4
-      if: |
-        ${{ matrix.python-version == '3.12' }} &&
-        ${{ matrix.os == 'ubuntu-latest' }}
-      with:
-        token: ${{ secrets.CODECOV_TOKEN }}
+        python -m pytest --cov=src
+    # - name: Upload results to Codecov
+    #   uses: codecov/codecov-action@v4
+    #   if: |
+    #     ${{ matrix.python-version == '3.13' }} &&
+    #     ${{ matrix.os == 'ubuntu-latest' }}
+    #   with:
+    #     token: ${{ secrets.CODECOV_TOKEN }}

--- a/docs_src/source/tutorials/MMUSC.ipynb
+++ b/docs_src/source/tutorials/MMUSC.ipynb
@@ -102,7 +102,7 @@
     "qcircuits = []\n",
     "\n",
     "# Maximum number of resonator modes we will be considering\n",
-    "N_max = 6\n",
+    "N_max = 5\n",
     "\n",
     "\n",
     "for N in range(1,N_max+1):\n",


### PR DESCRIPTION
Something changed in the GitHub Actions runner which means I now have to explicitly install sqlite.
The MMUSC tutorial failed on linux machines, because it only has 5 'N's instead of the 6 that Windows can find.
I'll explain more in an email.